### PR TITLE
Check in Synthetic Data Generator - MCAR only

### DIFF
--- a/examples/demo_synthetic_data_generation.py
+++ b/examples/demo_synthetic_data_generation.py
@@ -1,3 +1,14 @@
+"""The following script demonstrates how to generate synthetic data using the nearest_neighbors package.
+It shows how to explore the results of the synthetic data generation, and various ways in which the 
+data generation parameters can be customized. It also documents how parameters can be accessed from the
+instance of the data generator, and how the full state dictionary can be accessed to see the true data
+before noise, the noisy data, and the availability mask, etc.
+
+To run this script, ensure you're in the root directory of the package and run:
+```
+    python examples/demo_synthetic_data_generation.py
+```
+"""
 from nearest_neighbors.dataloader_factory import NNData
 
 print("====== Synthetic Data Demo: Exploring Parameters and Full State Keys ======")

--- a/examples/demo_synthetic_data_generation.py
+++ b/examples/demo_synthetic_data_generation.py
@@ -1,5 +1,5 @@
 """The following script demonstrates how to generate synthetic data using the nearest_neighbors package.
-It shows how to explore the results of the synthetic data generation, and various ways in which the 
+It shows how to explore the results of the synthetic data generation, and various ways in which the
 data generation parameters can be customized. It also documents how parameters can be accessed from the
 instance of the data generator, and how the full state dictionary can be accessed to see the true data
 before noise, the noisy data, and the availability mask, etc.
@@ -9,6 +9,7 @@ To run this script, ensure you're in the root directory of the package and run:
     python examples/demo_synthetic_data_generation.py
 ```
 """
+
 from nearest_neighbors.dataloader_factory import NNData
 
 print("====== Synthetic Data Demo: Exploring Parameters and Full State Keys ======")

--- a/examples/demo_synthetic_data_generation.py
+++ b/examples/demo_synthetic_data_generation.py
@@ -1,0 +1,56 @@
+from nearest_neighbors.dataloader_factory import NNData
+
+print("====== Synthetic Data Demo: Exploring Parameters and Full State Keys ======")
+print("\nDataset Help Information:")
+NNData.help("synthetic_data")
+
+# Example 1: Multiplicative model (default) with custom parameters.
+print("\n====== Example 1: Multiplicative Model (Default) ======")
+data_generator = NNData.create(
+    "synthetic_data", num_rows=10, num_cols=10, seed=29, miss_prob=0.2
+)
+data, mask = data_generator.process_data_scalar()
+
+print("\nWe can see the produced data (multiplicative model) below:")
+print("Observed Data:")
+print(data)
+print("\nAvailability Mask (1 if observed, 0 if missing):")
+print(mask)
+
+# Example 2: Additive model with lower noise and higher missing probability.
+print("\n====== Example 2: Additive Model with Lower Noise ======")
+data_generator2 = NNData.create(
+    "synthetic_data",
+    num_rows=10,
+    num_cols=10,
+    seed=29,
+    miss_prob=0.3,
+    latent_factor_combination_model="additive",
+    stddev_noise=0.5,
+)
+data2, mask2 = data_generator2.process_data_scalar()
+
+print("\nWe can see the produced data (additive model with lower noise) below:")
+print("Observed Data:")
+print(data2)
+print("\nAvailability Mask (1 if observed, 0 if missing):")
+print(mask2)
+
+# Explore the keys of the full state dictionary.
+print("\n====== Full State Dictionary Keys ======")
+full_state = data_generator.get_full_state_as_dict(include_metadata=True)
+print("Keys in the full state dictionary:")
+print(list(full_state.keys()))
+print(
+    "For instance, we may want to see the true noisy data and the true data before noise:"
+)
+print("\nFirst row from 'full_data_noisy', with no missing values:")
+print(full_state["full_data_noisy"][0])
+print("\nFirst row from 'full_data_true', before the noise was added:")
+print(full_state["full_data_true"][0])
+
+
+print("\nFor debugging, we can also access the full generation metadata:")
+gen_metadata = full_state["generation_metadata"]
+for key, value in gen_metadata.items():
+    print(f"\t{key}: {value}")

--- a/src/nearest_neighbors/data_types.py
+++ b/src/nearest_neighbors/data_types.py
@@ -126,7 +126,7 @@ class DistributionKernelMMD(DataType):
         mixture = np.vstack(arrays_to_stack)
         return mixture
 
-      
+
 class DistributionWassersteinSamples(DataType):
     """Data type for distributions using Wasserstein distance
     where distributions are made with samples with the same number of samples.

--- a/src/nearest_neighbors/dataloader_base.py
+++ b/src/nearest_neighbors/dataloader_base.py
@@ -74,3 +74,13 @@ class NNDataLoader(ABC):
 
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def get_full_state_as_dict(self, include_metadata: bool = False) -> dict:
+        """A helpful debugging tool: returns the full state of the data loader as a dictionary.
+
+        Args:
+            include_metadata (bool): whether to include metadata in the dictionary. Default: False.
+
+        """
+        raise NotImplementedError

--- a/src/nearest_neighbors/datasets/synthetic_data/__init__.py
+++ b/src/nearest_neighbors/datasets/synthetic_data/__init__.py
@@ -1,0 +1,1 @@
+from .loader import SyntheticDataLoader  # noqa: F401

--- a/src/nearest_neighbors/datasets/synthetic_data/loader.py
+++ b/src/nearest_neighbors/datasets/synthetic_data/loader.py
@@ -1,0 +1,285 @@
+from nearest_neighbors.dataloader_base import NNDataLoader
+from nearest_neighbors.dataloader_factory import register_dataset
+import numpy as np
+from typing import Any
+
+params = {
+    "num_rows": (int, 100, "Number of rows in the dataset"),
+    "num_cols": (int, 100, "Number of columns in the dataset"),
+    "seed": (int, None, "Random seed for reproducibility"),
+    "stddev_noise": (float, 1, "Standard deviation of noise"),
+    "snr": (
+        float,
+        None,
+        "Signal-to-noise ratio (defaults to None—if provided, overrides stddev_noise)",
+    ),
+    "mode": (str, "mcar", "Missing data mechanism ('mcar' or 'mnar')"),
+    "miss_prob": (float, 0.5, "Probability of missing values (for MCAR)"),
+    "mnar_deter": (
+        bool,
+        True,
+        "Whether to use deterministic observation probabilities for MNAR",
+    ),
+    "latent_factor_combination_model": (
+        str,
+        "multiplicative",
+        "Additive or multiplicative model for combining latent factors",
+    ),
+    "rho": (
+        float,
+        0.5,
+        "Parameter for data generation in the nonlinear additive model. I.e. lambda in the Holder signal",
+    ),
+    "latent_factor_dimensionality": (int, 4, "Dimensionality of the latent factors"),
+    "simulated_data_nonlin_transform": (
+        str,
+        "",
+        "Nonlinear transformation to apply to the synthetic data, if any",
+    ),
+}
+
+
+@register_dataset("synthetic_data", params)
+class SyntheticDataLoader(NNDataLoader):
+    """Data from the Heartsteps V1 study formatted into a matrix or tensor.
+    To initialize with default settings, use: NNData.create("synthetic")
+    """
+
+    def __init__(
+        self,
+        download: bool = False,  # this is not needed for synthetic data but is kept for consistency
+        save_dir: str = "./",
+        agg: str = "mean",
+        save_processed: bool = False,
+        # above are superconstructor args
+        # below are specific args
+        num_rows: int = 100,
+        num_cols: int = 100,
+        mode: str = "mcar",
+        rho: float = 0.5,
+        seed: int | None = None,
+        stddev_noise: float = 1,
+        snr: float | None = None,
+        miss_prob: float = 0.5,
+        mnar_deter: bool = True,
+        latent_factor_combination_model: str = "multiplicative",
+        latent_factor_dimensionality: int = 4,
+        simulated_data_nonlin_transform: str = "",
+        **kwargs: Any,
+    ):
+        """Initializes the Synthetic data loader.
+
+        Args:
+        ----
+            download: Whether to download the data locally. Default: False. If True, data is downloaded at save_dir
+            save_dir: Directory to download the data to or where it already exists. Also the directory where the processed data will be. Default: "./" (current directory).
+            agg: Aggregation method to use to create scalar dataset. Default: "mean".
+            save_processed: Whether to save the processed data. Default: False.
+            num_rows: Number of rows in the dataset. Default: 100.
+            num_cols: Number of columns in the dataset. Default: 100.
+            mode: Missing data mechanism ('mcar' or 'mnar'). Default: "mcar".
+            rho: Parameter for data generation, or lambda in the Holder signal. Default: 0.5.
+            seed: Random seed for reproducibility. Default: None.
+            stddev_noise: Standard deviation of noise. Default: 1.
+            snr: Signal-to-noise ratio. Default: None. If provided, overrides stddev_noise.
+            miss_prob: Probability of missing values (for MCAR). Default: 0.5.
+            mnar_deter: Whether to use deterministic observation probabilities for MNAR. Default: True.
+            latent_factor_combination_model: Additive or multiplicative model for combining latent factors. Default: "multiplicative".
+            latent_factor_dimensionality: Dimensionality of the latent factors. Default: 4.
+            simulated_data_nonlin_transform: Nonlinear transformation to apply to the synthetic data, if any. Default: "", i.e. no transformation.
+            kwargs: Additional keyword arguments.
+
+        """
+        super().__init__(
+            download=download,
+            save_dir=save_dir,
+            agg=agg,
+            save_processed=save_processed,
+            **kwargs,
+        )
+        self.num_rows = num_rows
+        self.num_cols = num_cols
+        self.mode = mode
+        self.rho = rho
+        self.stddev_noise = stddev_noise
+        self.snr = snr  # if provided, this overrides stddev_noise
+        self.miss_prob = miss_prob
+        self.mnar_deter = mnar_deter
+        self.latent_factor_combination_model = (
+            latent_factor_combination_model  # "multiplicative" or "additive"
+        )
+        self.latent_factor_dimensionality = latent_factor_dimensionality
+        self.simulated_data_nonlin_transform = simulated_data_nonlin_transform
+        self.init_seed = seed
+        if seed is not None:
+            np.random.seed(
+                seed=seed
+            )  # instantiate random seed if provided but do it only once here
+
+    def download_data(self) -> None:
+        """Nothing to download for synthetic data"""
+        print(
+            "Warning: 'download' arg set to true, but there is no data to download when using synthetic data."
+        )
+        pass
+
+    def _generate_simulated_data(self) -> None:
+        """Generates the simulated data with no missing values"""
+        # row and column latent factors:
+        U = (
+            np.random.uniform(size=(self.num_rows, self.latent_factor_dimensionality))
+            - 0.5
+        )  # U ~ Uniform(-0.5, 0.5), shape (num_rows, latent_factor_dimensionality)
+        V = (
+            np.random.uniform(size=(self.num_cols, self.latent_factor_dimensionality))
+            - 0.5
+        )  # V ~ Uniform(-0.5, 0.5), shape (num_cols, latent_factor_dimensionality)
+
+        # Let us define a tensor Y constructed from U and V
+        if self.latent_factor_combination_model == "additive":
+            print("Additive model")
+            # ... such that Y_i,j = |U_i + V_j|^rho * sign(U_i + V_j)
+            # This Holder Continuous f(U,V), allows for a potentially non-linear relationship between U and V
+            # vide: https://doi.org/10.48550/arXiv.2411.12965
+            Y = np.abs(U[:, np.newaxis] + V) ** self.rho * np.sign(
+                U[:, np.newaxis] + V
+            )  # shape (latent_factor_dimensionality, latent_factor_dimensionality)
+            Y = Y.sum(
+                axis=2
+            )  # collapse the latent factor dimensionality to get Y of shape (num_rows, num_cols)
+        elif self.latent_factor_combination_model == "multiplicative":
+            # ...such that Y_i,j = U_i * V_j
+            Y = U @ V.T
+        else:
+            raise ValueError("Invalid latent_factor_combination_model arg provided.")
+        # print("Y shape: ", Y.shape)
+        self._transform_simulated_data(Y)
+        data_true = Y.copy()  # i.e. "Theta"
+
+        if (
+            self.snr is not None
+        ):  # if signal-to-noise ratio provided, override stddev_noise
+            signal_var = np.mean(Y**2)
+            stddev_noise = np.sqrt(signal_var / self.snr)
+            self.stddev_noise = (
+                stddev_noise  # update the instance variable for future reference
+            )
+        Y += self.stddev_noise * np.random.normal(size=(self.num_rows, self.num_cols))
+        data_noisy = Y.copy()
+
+        self.row_latent = U
+        self.data_true = data_true
+        self.data_noisy = data_noisy
+        self.col_latent = V
+
+    def _make_mcar(self) -> None:
+        """Makes values missing completely at random (MCAR)"""
+        # M ~ Bernoulli(self.miss_prob), shape (self.num_rows, self.num_cols)
+        missing_mask = (
+            np.random.binomial(1, self.miss_prob, size=(self.num_rows, self.num_cols))
+            == 1
+        )
+        data_obs = self.data_noisy.copy()
+        data_obs[missing_mask] = np.nan
+        A = ~missing_mask  # A = NOT M, i.e. A_ij = 1 if Y_ij is observed, 0 if missing
+        self.data_obs = data_obs
+        self.availability_mask = A
+
+    def _make_mnar(self) -> None:
+        raise NotImplementedError("MNAR yet to be implemented")
+        # TODO: Aashish/Caleb/Kyuesong/Tatha: come back to this later
+
+    def get_full_state_as_dict(self, include_metadata: bool = False) -> dict:
+        """Returns the full state of this object as a dictionary"""
+        return_dict = {
+            "data_observed": self.data_obs,
+            "observed_entries": self.availability_mask,
+            "full_data_true": self.data_true,
+            "full_data_noisy": self.data_noisy,
+            "row_latent": self.row_latent,
+            "col_latent": self.col_latent,
+        }
+        if include_metadata:
+            return_dict["generation_metadata"] = {
+                "num_rows": self.num_rows,
+                "num_cols": self.num_cols,
+                "mode": self.mode,
+                "stddev_noise": self.stddev_noise,
+                "snr": self.snr,
+                "miss_prob": self.miss_prob,
+                "mnar_deter": self.mnar_deter,
+                "latent_factor_combination_model": self.latent_factor_combination_model,
+                "latent_factor_dimensionality": self.latent_factor_dimensionality,
+                "simulated_data_nonlin_transform": self.simulated_data_nonlin_transform,
+                "seed_at_generation": self.init_seed,
+                "rho": self.rho,
+            }
+        return return_dict
+
+    def run_simulation(self) -> None:
+        """Runs the simulation and makes data missing as needed"""
+        self._generate_simulated_data()
+        if self.mode == "mcar":
+            self._make_mcar()
+        elif self.mode == "mnar":
+            self._make_mnar()
+
+    def process_data_scalar(
+        self,
+        cached: bool = False,
+        agg: str = "mean",  # TODO Caleb, is it safe to remove these args?
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Forces a simulation run, and processes synthetic data as scalar form.
+
+        Args:
+        ----
+            cached: Whether to use cached data. Default: False.
+            agg: Aggregation method to use. Default: "mean".
+
+        Returns:
+        -------
+            tuple: Tuple containing:
+                - np.ndarray: Data matrix with missing values as NaN
+                - np.ndarray: Binary availability mask (1 for observed, 0 for missing)
+
+        """
+        self.run_simulation()
+        state_dict = self.get_full_state_as_dict(include_metadata=False)
+        observed_data = state_dict["data_observed"]
+        availability_mask = state_dict["observed_entries"]
+        return (observed_data, availability_mask)
+
+    def process_data_distribution(
+        self, cached: bool = False
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Method not yet implemented for synthetic data"""
+        # TODO Caleb, Kyuesong: is this even well-defined for synthetic data?
+        raise NotImplementedError(
+            "Distributional setting not yet implemented for synthetic data"
+        )
+
+    # HELPER FUNCTIONS
+    def _expit(self, x: np.ndarray) -> np.ndarray:
+        """Helper function to apply the logistic sigmoid function to an array"""
+        return np.exp(x) / (1 + np.exp(x))
+
+    def _transform_simulated_data(self, Y: np.ndarray) -> np.ndarray:
+        """Apply a nonlinear transformation to the simulated data. Stored here since it's messy to have it in the main simulation."""
+        non_lin = self.simulated_data_nonlin_transform
+        if non_lin == "":
+            return Y
+        if non_lin == "expit":  # logistic sigmoid
+            Y = self._expit(Y)
+        elif non_lin == "tanh":
+            Y = np.tanh(Y)
+        elif non_lin == "sin":
+            Y = np.sin(Y)
+        elif non_lin == "cubic":
+            Y = Y**3
+        elif non_lin == "sinh":
+            Y = np.sinh(Y)
+        else:
+            raise ValueError(
+                "non_lin must be one of '', 'expit', 'tanh', 'sin', 'cubic', or 'sinh'."
+            )
+        return Y


### PR DESCRIPTION
This addresses #44 and #20. So far it only works on MCAR though. I'm not sure I understand MNAR enough to write it up. 

I've been able to combine @kyuseongchoi5's python code[1] with @Tathagata-S's R code[2] & merge them into the structure @calebchin created. @calebchin and I discussed future work on the structure & potentially a separate factory for synthetic data. We also should want to allow the user to create MCAR/MNAR effects on non-synthetic data, which this does review not yet do. 

For now, you can test it and explore the functionality by running `examples/demo_synthetic_data_generation.py`; tests will be added later. 

N.B.:
[1] @kyuseongchoi5's `gendata_lin_mcar` function corresponds to the default behavior, i.e. `latent_factor_combination_model` being `multiplicative`, since he uses Y = UV^T.  Additionally, the `simulated_data_nonlin_transform` flag does the same thing that the `non_lin` param does in the original `gendata_nonlin_mcar` function. 


[2] @Tathagata-S's use of a nonlinear additive method (i.e., a holder continuous fn such that Y_i,j = |U_i + V_j|^rho * sign(U_i + V_j)) can be simulated by setting the `latent_factor_combination_model` to `additive`. 